### PR TITLE
Don't syncronize the current running build with the previous one

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -452,7 +452,7 @@ public class DiscardBuildPublisher extends Recorder {
 	}
 
 	public BuildStepMonitor getRequiredMonitorService() {
-		return BuildStepMonitor.BUILD;
+		return BuildStepMonitor.NONE;
 	}
 
 	// for test


### PR DESCRIPTION
This is in case we run concurrent builds, when a build gets blocked to  not block all the other which waits for it's status. 
For example, we run concurrent builds on 92 nodes, on one node we get blocked, all the other 91 will wait for that one to finish so we will have the whole system blocked. 
Also without this change the previous commit https://github.com/jenkinsci/discard-old-build-plugin/commit/e05d0e3021e08399910ded0bdb6639f413276ab4 doesn't brings in so much value. 
