### PR TITLE
Adding a default empty constructor so the arg based constructor can b…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -115,6 +115,38 @@ public class DiscardBuildPublisher extends Recorder {
         this.regexp = regexp;
         this.keepLastBuilds = keepLastBuilds;
     }
+    
+    //Default Constructor is required by Groovy Explicitly to be able to use defined arg constructors in scripts.
+    DiscardBuildPublisher()
+    {
+        this.daysToKeep = 7;
+        this.intervalDaysToKeep = 7;
+        this.numToKeep = 10;
+        this.intervalNumToKeep = 7;
+
+        resultsToDiscard = new HashSet<Result>();
+        if (true) {
+            resultsToDiscard.add(Result.SUCCESS);
+        }
+        if (true) {
+            resultsToDiscard.add(Result.UNSTABLE);
+        }
+        if (false) {
+            resultsToDiscard.add(Result.FAILURE);
+        }
+        if (true) {
+            resultsToDiscard.add(Result.NOT_BUILT);
+        }
+        if (true) {
+            resultsToDiscard.add(Result.ABORTED);
+        }
+
+        this.minLogFileSize = parseLong("");
+        this.maxLogFileSize = parseLong("");
+
+        this.regexp = "";
+        this.keepLastBuilds = true;
+    }
 
     private static int parse(String p) {
         if (p == null) return -1;


### PR DESCRIPTION
Adding a default empty constructor so the arg based constructor can be accessed via the Groovy script plug-in, this is due to a quirk with the Groovy environment which requires the normally implicit constructor to have to be explicitly declared for the arg based constructor to be available for the scripts.
