### PR TITLE
Updated POM and all Jelly Files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,6 +4,7 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.43</version><!-- which version of Jenkins is this plugin built against? -->
+    <relativePath />
   </parent>
 
   <groupId>jp.shiftinc.jenkins.plugins</groupId>
@@ -35,13 +36,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.28.2</version>
+      <version>1.9.5</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>2.1</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <description>Add post-build step to discard old builds with detail configuration</description>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>3.43</jenkins.version>
     <java.level>8</java.level>
   </properties>
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
@@ -35,13 +35,13 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>1.9.5</version>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
-      <version>1.3</version>
+      <version>2.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -64,11 +64,11 @@
       <name>Joey Jiao</name>
       <email>joey.jiaojg@gmail.com</email>
     </developer>
-    <developer>
-      <id>BenjaminBeggs</id>
-      <name>Benjamin Beggs</name>
-      <email>benjaminbeggspublic@yahoo.com</email>
-    </developer>
+     <developer>
+       <id>BenjaminBeggs</id>
+       <name>Benjamin Beggs</name>
+       <email>benjaminbeggspublic@yahoo.com</email>
+     </developer>
   </developers>
 
   <scm>
@@ -77,6 +77,6 @@
     <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
   </scm>
 
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -12,28 +12,32 @@
   <packaging>hpi</packaging>
   <name>Discard Old Build plugin</name>
   <description>Add post-build step to discard old builds with detail configuration</description>
-  
+
+  <properties>
+    <jenkins.version>2.60.3</jenkins.version>
+    <java.level>8</java.level>
+  </properties>
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
   <dependencies>
-  	<dependency>
-  		<groupId>org.mockito</groupId>
-  		<artifactId>mockito-core</artifactId>
-  		<version>1.9.5</version>
-  		<scope>test</scope>
-  	</dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>1.9.5</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
@@ -41,26 +45,19 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  
+
   <developers>
     <developer>
       <id>nkns165</id>
       <name>Hiroko Tamagawa</name>
       <email>nkns165@gmail.com</email>
     </developer>
-     <developer>
-       <id>joeyjiao</id>
-       <name>Joey Jiao</name>
-       <email>joey.jiaojg@gmail.com</email>
-     </developer>
+    <developer>
+      <id>joeyjiao</id>
+      <name>Joey Jiao</name>
+      <email>joey.jiaojg@gmail.com</email>
+    </developer>
   </developers>
-
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
 
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/discard-old-build-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -74,9 +74,9 @@
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/discard-old-build-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/discard-old-build-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
+    <url>http://github.com/jenkinsci/discard-old-build-plugin</url>
   </scm>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
+  <url>http://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.515</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>3.43</version><!-- which version of Jenkins is this plugin built against? -->
   </parent>
 
   <groupId>jp.shiftinc.jenkins.plugins</groupId>
@@ -29,13 +29,8 @@
   </pluginRepositories>
   <dependencies>
   	<dependency>
-  		<groupId>maven</groupId>
-  		<artifactId>dom4j</artifactId>
-  		<version>1.7-20060614</version>
-  	</dependency>
-  	<dependency>
   		<groupId>org.mockito</groupId>
-  		<artifactId>mockito-all</artifactId>
+  		<artifactId>mockito-core</artifactId>
   		<version>1.9.5</version>
   		<scope>test</scope>
   	</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,6 @@
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
     <version>3.43</version><!-- which version of Jenkins is this plugin built against? -->
-    <relativePath />
   </parent>
 
   <groupId>jp.shiftinc.jenkins.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,34 +59,16 @@
       <name>Hiroko Tamagawa</name>
       <email>nkns165@gmail.com</email>
     </developer>
-    <developer>
-      <id>joeyjiao</id>
-      <name>Joey Jiao</name>
-      <email>joey.jiaojg@gmail.com</email>
-    </developer>
-<<<<<<< Updated upstream
-     <developer>
-       <id>BenjaminBeggs</id>
-       <name>Benjamin Beggs</name>
-       <email>benjaminbeggspublic@yahoo.com</email>
-     </developer>
      <developer>
        <id>joeyjiao</id>
        <name>Joey Jiao</name>
        <email>joey.jiaojg@gmail.com</email>
      </developer>
-     <developer>
-       <id>BenjaminBeggs</id>
-       <name>Benjamin Beggs</name>
-       <email>benjaminbeggspublic@yahoo.com</email>
-     </developer>
-=======
     <developer>
       <id>BenjaminBeggs</id>
       <name>Benjamin Beggs</name>
       <email>benjaminbeggspublic@yahoo.com</email>
     </developer>
->>>>>>> Stashed changes
   </developers>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,13 @@
     </dependency>
   </dependencies>
 
+  <licenses>
+    <license>
+      <name>MIT</name>
+      <url>http://www.opensource.org/licenses/mit-license.php</url>
+    </license>
+  </licenses>
+
   <developers>
     <developer>
       <id>nkns165</id>
@@ -56,6 +63,11 @@
       <id>joeyjiao</id>
       <name>Joey Jiao</name>
       <email>joey.jiaojg@gmail.com</email>
+    </developer>
+    <developer>
+      <id>BenjaminBeggs</id>
+      <name>Benjamin Beggs</name>
+      <email>benjaminbeggspublic@yahoo.com</email>
     </developer>
   </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,12 @@
   		<version>1.9.5</version>
   		<scope>test</scope>
   	</dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   
   <developers>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,6 +1,7 @@
 <!--
   This view is used to render the installed plugins page.
 -->
+<?jelly escape-by-default='true'?>
 <div>
   This plugin enables detail configuration to discard old builds like using
     logfile size / status / days/ intervals days / build num / logfile regular expression.

--- a/src/main/resources/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher/config.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
     <f:entry title="${%DaysToKeep}" field="daysToKeep">
       <f:textbox />


### PR DESCRIPTION
Development Environment:

Maven Version - 3.6.0
JDK Version - 1.8.0_171
OS - Windows10
I tried to run discard-old-build-plugin on my machine using mvn clean install command, but InjectedTest failure occurred. That test is not designed for Windows. And so I updated the POM to the recent version and done few required changes.

## **Proposed Changelog enteries**
-  Updated Version
- Removed dom4j
- Added Jenkins version and java level
- Removed distributionManagement
- Added harmcrest-core 1.3
- Changed mokito-all to mokito-core
- HTTPs done in repositories and pluginRepositories

Find discussion [here](https://github.com/jenkinsci/discard-old-build-plugin/pull/9)

## **Desired Reviewers**
@oleg-nenashev @BenjaminBeggs 