### PR TITLE
Require Jenkins 2.346.3 or newer

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.4</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,16 @@
-// Use a standard build step from https://github.com/jenkins-infra/pipeline-library
-buildPlugin(configurations: [
-  [ platform: "windows", jdk: "8", jenkins: "1.642", javaLevel: 7],
-  [ platform: "linux", jdk: "8", jenkins: "1.642", javaLevel: 7]
-])
+#!/usr/bin/env groovy
+
+/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
+buildPlugin(
+  // Container agents start faster and are easier to administer
+  useContainerAgent: true,
+  // Show failures on all configurations
+  failFast: false,
+  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
+  // Test Java 8 temporarily
+  configurations: [
+    [platform: 'windows', jdk: '17', jenkins: '2.382'],
+    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
+    [platform: 'linux',   jdk: '8'],
+  ]
+)

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
   </scm>
 
-  <url>https://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
+  <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
 
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,8 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.642</version><!-- which version of Jenkins is this plugin built against? -->
+    <version>4.51</version>
+    <relativePath />
   </parent>
 
   <groupId>jp.shiftinc.jenkins.plugins</groupId>
@@ -14,8 +15,7 @@
   <description>Jenkins plugin to manage old build discards with more user-configurability than core functionality</description>
 
   <properties>
-    <jenkins.version>1.642</jenkins.version>
-    <java.level>7</java.level>
+    <jenkins.version>2.346.3</jenkins.version>
   </properties>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all needed artifacts -->
@@ -34,17 +34,10 @@
   </pluginRepositories>
 
   <dependencies>
-  	<dependency>
-  		<groupId>org.mockito</groupId>
-  		<artifactId>mockito-core</artifactId>
-  		<version>2.28.2</version>
-  		<scope>test</scope>
-  	</dependency>
     <dependency>
-        <groupId>org.hamcrest</groupId>
-        <artifactId>hamcrest</artifactId>
-        <version>2.1</version>
-        <scope>test</scope>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 
@@ -73,13 +66,6 @@
     </developer>
   </developers>
 
-  <distributionManagement>
-    <repository>
-      <id>maven.jenkins-ci.org</id>
-      <url>https://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-    </repository>
-  </distributionManagement>
-
   <scm>
     <connection>scm:git:ssh://github.com/jenkinsci/discard-old-build-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/discard-old-build-plugin.git</developerConnection>
@@ -88,4 +74,15 @@
 
   <url>https://wiki.jenkins-ci.org/display/JENKINS/Discard+Old+Build+plugin</url>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.346.x</artifactId>
+        <version>1742.vb_70478c1b_25f</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,12 +9,15 @@
 
   <groupId>jp.shiftinc.jenkins.plugins</groupId>
   <artifactId>discard-old-build</artifactId>
-  <version>1.X-feature-test</version>
+  <version>${revision}${changelist}</version>
   <packaging>hpi</packaging>
   <name>Discard Old Build plugin</name>
   <description>Jenkins plugin to manage old build discards with more user-configurability than core functionality</description>
 
   <properties>
+    <revision>1.07</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <gitHubRepo>jenkinsci/discard-old-build-plugin</gitHubRepo>
     <jenkins.version>2.346.3</jenkins.version>
   </properties>
 
@@ -67,9 +70,9 @@
   </developers>
 
   <scm>
-    <connection>scm:git:https://github.com/jenkinsci/discard-old-build-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/discard-old-build-plugin.git</developerConnection>
-    <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
+    <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <url>https://github.com/${gitHubRepo}</url>
   </scm>
 
   <url>https://github.com/jenkinsci/discard-old-build-plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -67,8 +67,8 @@
   </developers>
 
   <scm>
-    <connection>scm:git:ssh://github.com/jenkinsci/discard-old-build-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/jenkinsci/discard-old-build-plugin.git</developerConnection>
+    <connection>scm:git:https://github.com/jenkinsci/discard-old-build-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/discard-old-build-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/discard-old-build-plugin</url>
   </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
   <scm>
     <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
     <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <tag>${scmTag}</tag>
     <url>https://github.com/${gitHubRepo}</url>
   </scm>
 

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -217,7 +217,6 @@ public class DiscardBuildPublisher extends Recorder {
     }
 
     private ArrayList<Run<?, ?>> discardLastBuilds(AbstractBuild<?, ?> build, BuildListener listener, RunList<Run<?, ?>> builds) {
-        Job<?, ?> job = (Job<?, ?>) build.getParent();
         ExtendRunList newList = new ExtendRunList();
         for (Run<?, ?> r : builds) {
             newList.add(r);
@@ -226,8 +225,7 @@ public class DiscardBuildPublisher extends Recorder {
     }
 
     private ArrayList<Run<?, ?>> HoldMaxBuilds(ArrayList<Run<?, ?>> listIn, BuildListener listener, int maxCount) {
-        ArrayList<Run<?, ?>> listUpdt = new ArrayList<Run<?, ?>>();
-        listUpdt = listIn;
+        ArrayList<Run<?, ?>> listUpdt = listIn;
         int listCnt = listUpdt.size();
         if (listCnt < maxCount||listCnt == maxCount){ // clear discard list if beneath minimum build quantity
             listener.getLogger().println("Too few builds present to remove any, clearing discard list.");
@@ -368,10 +366,9 @@ public class DiscardBuildPublisher extends Recorder {
     }
 
     private ArrayList<Run<?, ?>> updateBuildsList(AbstractBuild<?, ?> build, BuildListener listener) {
-        RunList<Run<?, ?>> builds = new RunList<Run<?, ?>>();
-        ArrayList<Run<?, ?>> list = new ArrayList<Run<?, ?>>();
+        ArrayList<Run<?, ?>> list;
         Job<?, ?> job = (Job<?, ?>) build.getParent();
-        builds = (RunList<Run<?, ?>>) job.getBuilds();
+        RunList<Run<?, ?>> builds = (RunList<Run<?, ?>>) job.getBuilds();
         if (isKeepLastBuilds())
             list = keepLastBuilds(build, listener, builds);
         else

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.discardbuild;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import hudson.Extension;
 import hudson.Launcher;
 import hudson.model.*;
@@ -138,6 +140,8 @@ public class DiscardBuildPublisher extends Recorder {
         }
     }
 
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING",
+                        justification = "Replace in Java 11 with two argument FileReader call")
     private static boolean isRegexpMatch(File logFile, String regexp) throws IOException, InterruptedException {
         if (regexp == null) return false;
         String line;
@@ -166,6 +170,8 @@ public class DiscardBuildPublisher extends Recorder {
         }
     }
 
+    @SuppressFBWarnings(value = "SIC_INNER_SHOULD_BE_STATIC",
+                        justification = "Evaluate later if interest in the plugin rises")
     class ExtendRunList extends RunList<Run<?, ?>> {
         private ArrayList<Run<?, ?>> newList;
         ExtendRunList() {

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -483,10 +483,9 @@ public class DiscardBuildPublisher extends Recorder {
     /**
      * Descriptor for {@link DiscardBuildPublisher}. Used as a singleton. The class is
      * marked as public so that it can be accessed from views.
-     * <p/>
-     * <p/>
+     *
      * See
-     * <tt>src/main/resources/hudson/plugins/hello_world/HelloWorldBuilder/*.jelly</tt>
+     * <code>src/main/resources/hudson/plugins/hello_world/HelloWorldBuilder/*.jelly</code>
      * for the actual HTML fragment for the configuration screen.
      */
     @Extension

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -146,10 +146,11 @@ public class DiscardBuildPublisher extends Recorder {
         if (regexp == null) return false;
         String line;
         Pattern pattern = Pattern.compile(regexp);
-        BufferedReader reader = new BufferedReader(new FileReader(logFile));
-        while ((line = reader.readLine()) != null) {
-            Matcher matcher = pattern.matcher(line);
-            if (matcher.find()) return true;
+        try (BufferedReader reader = new BufferedReader(new FileReader(logFile))) {
+            while ((line = reader.readLine()) != null) {
+                Matcher matcher = pattern.matcher(line);
+                if (matcher.find()) return true;
+            }
         }
         return false;
     }

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -419,7 +419,7 @@ public class DiscardBuildPublisher extends Recorder {
      * @throws IOException when deletion failed
      */
     private void discardBuild(Run<?, ?> history, String reason, BuildListener listener) throws IOException {
-        listener.getLogger().printf("#%d is removed because %s\n", history.getNumber(), reason); //$NON-NLS-1$
+        listener.getLogger().printf("#%d is removed because %s%n", history.getNumber(), reason); //$NON-NLS-1$
         history.delete();
     }
 


### PR DESCRIPTION
## Modernize the plugin

- Test in CI with Java 8, Java 11, and Java 17
- Suppress 2 spotbugs warnings
- Use try with resources to assure file is closed
- Remove dead local stores
- Use correct newline markup in logging statement
- Require Jenkins 2.346.3 or newer
- Use correct SCM urls in pom file
- Use GitHub for documentation

The WMI Windows Agents plugin is an implied depenendecy of this plugin because the minimum Jenkins version of this plugin is older than the Jenkins core version that split WMI Windows Agents from Jenkins core.  This pull request modernizes the plugin so that a new release can be created using a more recent Jenkins version.  That will remove the implied dependency on the WMI Windows Agents plugin and make the plugin easier to maintain.

Jenkins 2.346.4 was selected as the minimum Jenkins version because it is one of the versions recommended by the "Choosing a version" page.  Over 30% of the installations of this plugin are already running 2.346.1 or newer.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

I used my administrator privileges on ci.jenkins.io to run the Jenkinsfile changes to confirm that they work as expected.