### PR TITLE
Require Java 11 and Jenkins 2.361.4 or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,6 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
 buildPlugin(
-  // Container agents start faster and are easier to administer
   useContainerAgent: true,
-  // Show failures on all configurations
-  failFast: false,
-  // Test Java 11 with minimum Jenkins version, Java 17 with a more recent version
-  // Test Java 8 temporarily
   configurations: [
-    [platform: 'windows', jdk: '17', jenkins: '2.382'],
-    [platform: 'linux',   jdk: '11', jenkins: '2.375.1'],
-    [platform: 'linux',   jdk: '8'],
-  ]
-)
+    [platform: 'linux', jdk: 17],
+    [platform: 'windows', jdk: 11],
+])

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.71</version>
     <relativePath />
   </parent>
 
@@ -18,7 +18,7 @@
     <revision>1.08</revision>
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/discard-old-build-plugin</gitHubRepo>
-    <jenkins.version>2.346.3</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>   
     <spotbugs.threshold>Low</spotbugs.threshold>
   </properties>
@@ -84,8 +84,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.346.x</artifactId>
-        <version>1763.v092b_8980a_f5e</version>
+        <artifactId>bom-2.361.x</artifactId>
+        <version>2102.v854b_fec19c92</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
## Require Java 11 and Jenkins 2.361.4 or newer

Over 90% of the installations of the most recent release (Dec 2022) are running on Jenkins 2.361.4 or newer.  Require Java 11 and Jenkins 2.361.4 or newer so that the parent pom updates can continue to be accepted and any maintainer that adopts the plugin can be confident in their use of Java 11.

### Testing done

Automated tests pass with Java 11 on Linux.  Rely on ci.jenkins.io for other tests.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
