### PR TITLE
Require Jenkins 2.479.1 and Jakarta EE 9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -35,8 +35,8 @@
     <changelist>-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/discard-old-build-plugin</gitHubRepo>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
     <spotless.check.skip>false</spotless.check.skip>
@@ -47,7 +47,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/discardbuild/DiscardBuildPublisher.java
@@ -409,9 +409,7 @@ public class DiscardBuildPublisher extends Recorder {
             throws IOException {
         if (!resultSet.isEmpty() && resultSet.contains(history.getResult())) {
             discardBuild(
-                    history,
-                    String.format("status %s is not to be kept", history.getResult()),
-                    listener); //$NON-NLS-1$
+                    history, "status %s is not to be kept".formatted(history.getResult()), listener); // $NON-NLS-1$
             return true;
         } else {
             return false;


### PR DESCRIPTION
## Require Jenkins 2.479.1 and Jakarta EE 9

Use Jakarta EE 9 so that we can eventually reduce the size of the compatibility layer in Jenkins core.

### Testing done

Automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
